### PR TITLE
Add example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@
 ```bash
 npm install jsreport-jade
 ```
+
+You can access the input data through jade locals and you can find helpers on `templateHelpers`
+```html
+doctype html
+html(lang="en")
+  head
+  body
+    p Hello from helper: #{templateHelpers.hello()}
+    p Hello from input data: #{hello}
+```
+
+**See the [playground example](https://playground.jsreport.net/studio/workspace/Vy9Y0fHz-/3)**


### PR DESCRIPTION
Took me a minute to find out helpers are on `templateHelpers`.
Adding this to the readme and also adding link to playground example
